### PR TITLE
Resolved: Metrics/LineLength has the wrong namespace - should be Layout

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -132,7 +132,7 @@ Metrics/CyclomaticComplexity:
 # * 警告 120文字
 # * 禁止 160文字
 # のイメージ
-Metrics/LineLength:
+Layout/LineLength:
   Max: 160
   Exclude:
     - "db/migrate/*.rb"


### PR DESCRIPTION
`Metrics/LineLength` moved to `Layout/LineLength` since rubocop 0.78.0

c.f. https://github.com/rubocop-hq/rubocop/pull/7542